### PR TITLE
Make it clearer that Http-Header-Case uses title

### DIFF
--- a/strenum/__init__.py
+++ b/strenum/__init__.py
@@ -304,7 +304,7 @@ class CobolCaseStrEnum(StrEnum):
 
 class HttpHeaderCaseStrEnum(StrEnum):
     """
-    A ``StrEnum`` where ``auto()`` will convert the name to `HTTP-Header-Case` to
+    A ``StrEnum`` where ``auto()`` will convert the name to `Http-Header-Case` to
     produce each member's value.
 
     Example usage::

--- a/strenum/_name_mangler.py
+++ b/strenum/_name_mangler.py
@@ -17,7 +17,7 @@ class _NameMangler:
             camel_Snake_Case
             Pascal_Snake_Case
             COBOL-CASE
-            HTTP-Header-Case
+            Http-Header-Case
 
         It _does not_ handle splitting spongebob case.
         """
@@ -121,7 +121,7 @@ class _NameMangler:
 
     def http_header(self, name):
         """
-        Convert a name to HTTP-Header-Case
+        Convert a name to Http-Header-Case
         """
 
         return "-".join(w.title() for w in self.words(name))

--- a/tests/test_name_mangler.py
+++ b/tests/test_name_mangler.py
@@ -7,6 +7,9 @@ word_split_test_data = (
     ("one", ["one"]),
     ("one two", ["one", "two"]),
     ("one two three", ["one", "two", "three"]),
+    ("ONETwoThree", ["ONE", "Two", "Three"]),
+    ("OneTWOThree", ["One", "TWO", "Three"]),
+    ("OneTwoTHREE", ["One", "Two", "THREE"]),
     ("fromCamelCase", ["from", "Camel", "Case"]),
     ("FromPascalCase", ["From", "Pascal", "Case"]),
     ("from-kebab-case", ["from", "kebab", "case"]),
@@ -15,7 +18,7 @@ word_split_test_data = (
     ("from_Camel_Snake_Case", ["from", "Camel", "Snake", "Case"]),
     ("From_Pascal_Snake_Case", ["From", "Pascal", "Snake", "Case"]),
     ("FROM-COBOL-CASE", ["FROM", "COBOL", "CASE"]),
-    ("FromHTTPHeaderCase", ["From", "HTTP", "Header", "Case"]),
+    ("From-Http-Header-Case", ["From", "Http", "Header", "Case"]),
 )
 
 


### PR DESCRIPTION
case by using that in the documentation and tests.

Also create separate tests for word splitting with acronym, which is a separate feature.
