### PR TITLE
 Fix stub including in a package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-*.pyi
-*.typed
+include *.pyi
+include *.typed
 include versioneer.py
 include strenum/_version.py


### PR DESCRIPTION
Fixes #24.

Checked on that code:

```python3
import enum

from strenum import StrEnum


class Fruit(StrEnum):
    APPLE = enum.auto()
    ORANGE = enum.auto()


concatenated = ", ".join([Fruit.APPLE.value, Fruit.ORANGE.value])
```

![image](https://github.com/irgeek/StrEnum/assets/28492051/54566858-cf9c-45a4-8f9a-c9166a7e223b)