### PR TITLE
Patch versioneer for Python 3.12 compatibility

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
readfp and SafeConfigParser has been deprecated since Python 3.2 and removed in Python 3.12 (due October 2023). Use read_file and ConfigParser instead.

https://docs.python.org/3/whatsnew/3.12.html#configparser